### PR TITLE
change to append mode when writing user command

### DIFF
--- a/src/init.d/user_command_renderer.py
+++ b/src/init.d/user_command_renderer.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _output_user_command(user_command, output_file):
-    with open(output_file, "w+") as f:
+    with open(output_file, "a+") as f:
         f.write(user_command)
 
 


### PR DESCRIPTION
Using `w+` will rewrite original user.sh. Which contains following lines.
```bash
set -o errexit
set -o nounset
set -o pipefail
```
Change to append mode