### PR TITLE
Use append mode to redirect user output

### DIFF
--- a/src/runtime.d/runtime_entry.sh
+++ b/src/runtime.d/runtime_entry.sh
@@ -93,7 +93,7 @@ echo "[INFO] Precommands finished"
 echo "[INFO] USER COMMAND START"
 (${RUNTIME_SCRIPT_DIR}/user.sh \
                     2> >(tee -a ${RUNTIME_LOG_DIR}/user.pai.stderr) \
-                    > >(tee -a ${RUNTIME_LOG_DIR}/user.pai.stdout)) > ${RUNTIME_LOG_DIR}/user.pai.all &
+                    > >(tee -a ${RUNTIME_LOG_DIR}/user.pai.stdout)) >> ${RUNTIME_LOG_DIR}/user.pai.all &
 
 USER_PID=$!
 


### PR DESCRIPTION
Previously, logrotate can not shrink  the log file size because program write content based on the file offset.
The offset always increase, so after log rotate, the log file keep the same size as before.
Change to append mode to avoid this issue.