### PR TITLE
jinja2==2.11.3 conflict with newest markupsafe, which remove soft_unicode module.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 kubernetes==11.0.0
 pyyaml==5.4
 requests==2.25.0
-jinja2==2.11.3
+jinja2==3.1.1
 pystache==0.5.4
 gitpython==3.1.11
 backoff==1.10.0


### PR DESCRIPTION
fix #49 

Signed-off-by: siaimes <34199488+siaimes@users.noreply.github.com>