### PR TITLE
fix no new line of job ssh.

### DIFF
--- a/src/plugins/ssh/init.py
+++ b/src/plugins/ssh/init.py
@@ -70,9 +70,9 @@ def prepare_job_ssh_key_pair(user_extension):
         secret_root = './ssh-secret'
         Path(secret_root).mkdir(exist_ok=True)
         with open(os.path.join(secret_root, "ssh-publickey"), "w") as publickey:
-            publickey.write(user_extension["jobSSH"]["pubKey"])
+            publickey.write(user_extension["jobSSH"]["pubKey"].strip() + '\n')
         with open(os.path.join(secret_root, "ssh-privatekey"), "w") as privatekey:
-            privatekey.write(user_extension["jobSSH"]["key"])
+            privatekey.write(user_extension["jobSSH"]["key"].strip() + '\n')
 
 
 def main():


### PR DESCRIPTION
Bug: A public key without a newline would cause two public keys to be pasted on the same line, making it impossible to ssh into the container.

Signed-off-by: siaimes <34199488+siaimes@users.noreply.github.com>